### PR TITLE
Fix msvc build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
+if(WIN32)
+    add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 find_package(Qt5 COMPONENTS Widgets Multimedia OpenGL Svg REQUIRED)
 
 set(BOX2D_VERSION 2.3.0)

--- a/GameState.cpp
+++ b/GameState.cpp
@@ -274,7 +274,7 @@ void GameState::resetShip()
     ship_touched_wall = false;
 }
 
-void GameState::addWater(const b2Vec2 position, const b2Vec2 size, const size_t seed, const uint flags)
+void GameState::addWater(const b2Vec2 position, const b2Vec2 size, const size_t seed, const unsigned int flags)
 {
     cout << "flop ";
     std::default_random_engine rng(seed);

--- a/GameState.h
+++ b/GameState.h
@@ -27,7 +27,7 @@ struct GameState : public b2ContactListener
     void addCrate(const b2Vec2 pos, const b2Vec2 velocity, const double angle);
     void clearCrates();
 
-    void addWater(const b2Vec2 pos, const b2Vec2 size, const size_t seed, const uint flags);
+    void addWater(const b2Vec2 pos, const b2Vec2 size, const size_t seed, const unsigned int flags);
     void clearWater();
 
     void addDoor(const b2Vec2 pos, const b2Vec2 size, const b2Vec2 delta);

--- a/data_polygons.cpp
+++ b/data_polygons.cpp
@@ -1,4 +1,5 @@
 #include "data_polygons.h"
+#include <algorithm>
 
 template <class T>
 inline void hash_combine(std::size_t& seed, const T& v)


### PR DESCRIPTION
Fix windows build to try this masterpiece.
It's obvious you don't give a sh*t about windows users, and I agree ! But still here are some fixes to build using MSVC.

# Feature List:
- Rename uint to unsigned int
- Add missing include
- Use a new define from the cmake to be able to use M_PI with MSVC

Fixed using msvc 14.24.28314

Chouchouuuuu